### PR TITLE
fixed "TypeError: dep.getResourceIdentifier is not a function"

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -400,7 +400,7 @@ class Compilation extends Tapable {
 		const dependencies = new Map();
 
 		const addDependency = dep => {
-			const resourceIdent = dep.getResourceIdentifier();
+			const resourceIdent = typeof dep.getResourceIdentifier === 'function' ? dep.getResourceIdentifier() : null;
 			if (resourceIdent) {
 				const factory = this.dependencyFactories.get(dep.constructor);
 				if (factory === undefined)


### PR DESCRIPTION
It's a bugfix for https://github.com/webpack/webpack/issues/6675.